### PR TITLE
CI: Automatically apply pull request labels for generic PR actions

### DIFF
--- a/.github/workflows/label-pull-requests.yml
+++ b/.github/workflows/label-pull-requests.yml
@@ -1,0 +1,74 @@
+name: Pull request labeler
+
+# FIXME: Find some way to make this trigger on general pull requests as well. `issue_comment` and `pull_request_review_comment` didn't seem to work.
+on:
+  pull_request:
+    types: [opened, reopened, converted_to_draft, ready_for_review, synchronize, edited, review_requested]
+  pull_request_review:
+    types: [submitted, dismissed]
+
+jobs:
+  label_pull_request:
+    runs-on: ubuntu-22.04
+    if: always() && github.repository == 'SerenityOS/serenity'
+    
+    steps:
+      - name: Label pull request
+        uses: actions/github-script@v6
+        with:
+          github-token: ${{ secrets.BUGGIEBOT }}
+          script: |
+            const prApprovedButAwaitingCiLabel = "✅ pr-approved-but-awaiting-ci";
+            const prNeedsReviewLabel = "👀 pr-needs-review";
+            const prWaitingForAuthorLabel = "⏳ pr-waiting-for-author";
+
+            function labelsForGenericPullRequestChange() {
+                return [prNeedsReviewLabel];
+            }
+
+            function labelsForPullRequestReviewSubmitted({ pull_request, review }) {
+                if (review.state.toLowerCase() === "approved") return [prApprovedButAwaitingCiLabel];
+
+                if (review.user.login === pull_request.user.login) return [prNeedsReviewLabel];
+
+                return [prWaitingForAuthorLabel];
+            }
+
+            function labelsForPullRequestConvertedToDraft() {
+                return [];
+            }
+
+            const eventHandlers = {
+                opened: labelsForGenericPullRequestChange,
+                reopened: labelsForGenericPullRequestChange,
+                submitted: labelsForPullRequestReviewSubmitted,
+                dismissed: labelsForGenericPullRequestChange,
+                converted_to_draft: labelsForPullRequestConvertedToDraft,
+                ready_for_review: labelsForGenericPullRequestChange,
+                synchronize: labelsForGenericPullRequestChange, // synchronize is triggered when the branch is changed
+                edited: labelsForGenericPullRequestChange,
+                review_requested: labelsForGenericPullRequestChange,
+            };
+
+            const eventName = context.payload.action;
+            const handlerForCurrentEvent = eventHandlers[eventName];
+
+            if (handlerForCurrentEvent) {
+                const isDraft = context.payload.pull_request.draft;
+                const labels = !isDraft ? handlerForCurrentEvent(context.payload) : [];
+
+                console.log(
+                    `Received '${eventName}' event for ${
+                        isDraft ? "draft" : "non-draft"
+                    } pull request, applying labels: ${labels}`
+                );
+
+                github.rest.issues.setLabels({
+                    issue_number: context.payload.pull_request.number,
+                    owner: context.repo.owner,
+                    repo: context.repo.repo,
+                    labels,
+                });
+            } else {
+                console.log(`::warning::No handler for the '${eventName}' event, not updating labels.`);
+            }


### PR DESCRIPTION
Generic PR actions include opening a PR, submit review comments, adding new commits, etc. This prevents the reviewer and PR submitter from having to manually bounce the labels back and forth in the general case.

This does not handle more subjective labels such as pr-is-blocked and pr-unclear. Unfortunately, there does not seem to be a GitHub Actions trigger for when a PR has merge conflicts.